### PR TITLE
Add CircleCI 2.0 with shield and CodeCov with shield. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+version: 2
+jobs:
+  node-latest: &test
+    docker:
+      - image: node:latest
+    working_directory: ~/react-testing-talk
+    steps:
+      - checkout
+      - run:
+          name: Update npm
+          command: 'npm install -g npm@latest'
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run:
+          name: Install dependencies
+          command: npm install
+      - run:
+          name: Testing
+          command: yarn test -- --coverage
+      - run:
+          name: Submitting code coverage to codecov
+          command: curl -s https://codecov.io/bash | bash
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+  node-8:
+    <<: *test
+    docker:
+      - image: node:8
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - node-latest
+      - node-8

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # React Testing Talk
 
 [![CircleCI](https://circleci.com/gh/MichaelDimmitt/react-testing-talk/tree/master.svg?style=shield)](https://circleci.com/gh/MichaelDimmitt/plugin-release/tree/master)
+[![CodeCov](https://img.shields.io/codecov/c/github/reergymerej/react-testing-talk.svg)](https://codecov.io/gh/reergymerej/react-testing-talk)
 
 https://www.meetup.com/React-JAX/events/251275752/
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # React Testing Talk
 
+[![CircleCI](https://circleci.com/gh/MichaelDimmitt/react-testing-talk/tree/master.svg?style=shield)](https://circleci.com/gh/MichaelDimmitt/plugin-release/tree/master)
+
 https://www.meetup.com/React-JAX/events/251275752/
 
 This is NOT why you should test.

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,0 @@
-machine:
-  node:
-    version: 10.5.0
-

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,4 @@
+machine:
+  node:
+    version: 10.5.0
+


### PR DESCRIPTION
72 percent code coverage, nice! 
For an example of what it looks like, see my default branch, https://github.com/MichaelDimmitt/react-testing-talk

I will be adding to the documentation for this pull request after it has been merged or closed. To improve readability of the process for setting code coverage up on a create react app.

link1: [code coverage from create react app issues page](https://github.com/facebook/create-react-app/issues/2825) 
link2: [code coverage from create react app docs](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#coverage-reporting)
link3: [use yarn test instead of npm test](https://github.com/facebook/create-react-app/issues/1363) 

Was a bit more of a challenge because we are using CircleCI instead of travis. But no worries got it working.

Lastly, codecov needed to be curled to get the report sent to their website.
```bash
#see file: .circleci/config.yml
curl -s https://codecov.io/bash | bash
```
CodeCov and CircleCI service is free for open source projects.